### PR TITLE
로직 변경 

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,10 +1,12 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
 }
+
 model user {
   userId        String         @id @map("user_id")
   userName      String         @unique @map("user_name")
@@ -15,8 +17,10 @@ model user {
   owningPlayer  owningPlayer[]
   record        record?
   team          team[]
+
   @@map("user")
 }
+
 model player {
   playerId     Int            @unique @default(autoincrement()) @map("player_id")
   playerName   String         @map("player_name")
@@ -28,9 +32,11 @@ model player {
   grade        Int            @default(1) @map("grade")
   owningPlayer owningPlayer[]
   tournament   tournament[]
+
   @@id([playerId, grade])
   @@map("player")
 }
+
 model owningPlayer {
   owningPlayerId Int    @id @default(autoincrement()) @map("owning_player_id")
   userId         String @map("user_id")
@@ -42,32 +48,34 @@ model owningPlayer {
   defender       team[] @relation("DefenderRelation")
   keeper         team[] @relation("KeeperRelation")
   striker        team[] @relation("StrikerRelation")
+
   @@index([playerId, grade], map: "owning_player_player_id_grade_fkey")
   @@index([userId], map: "owning_player_user_id_fkey")
   @@map("owning_player")
 }
+
 model team {
-  teamId                                                         Int                @id @default(autoincrement()) @map("team_id")
-  userId                                                         String             @map("user_id")
-  defenderId                                                     Int                @map("defender_id")
-  strikerId                                                      Int                @map("striker_id")
-  keeperId                                                       Int                @map("keeper_id")
-  matchHistoryAsA                                                matchHistory[]     @relation("teamAMatches")
-  matchHistoryAsB                                                matchHistory[]     @relation("teamBMatches")
-  defender                                                       owningPlayer       @relation("DefenderRelation", fields: [defenderId], references: [owningPlayerId], onDelete: Cascade)
-  keeper                                                         owningPlayer       @relation("KeeperRelation", fields: [keeperId], references: [owningPlayerId], onDelete: Cascade)
-  striker                                                        owningPlayer       @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
-  user                                                           user               @relation(fields: [userId], references: [userId], onDelete: Cascade)
-  tournament                                                     tournament[]
-  tournamentEntry                                                tournamentEntry[]
-  team_entry_a        tournamentMatch[] @relation("match_team_a")
-  team_entry_b        tournamentMatch[] @relation("match_team_b")
+  teamId           Int                @id @default(autoincrement()) @map("team_id")
+  userId           String             @map("user_id")
+  defenderId       Int                @map("defender_id")
+  strikerId        Int                @map("striker_id")
+  keeperId         Int                @map("keeper_id")
+  matchHistoryAsA  matchHistory[]     @relation("teamAMatches")
+  matchHistoryAsB  matchHistory[]     @relation("teamBMatches")
+  defender         owningPlayer       @relation("DefenderRelation", fields: [defenderId], references: [owningPlayerId], onDelete: Cascade)
+  keeper           owningPlayer       @relation("KeeperRelation", fields: [keeperId], references: [owningPlayerId], onDelete: Cascade)
+  striker          owningPlayer       @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
+  user             user               @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  tournament       tournament[]
+  tournament_entry tournament_entry[]
+
   @@index([defenderId], map: "team_defender_id_fkey")
   @@index([keeperId], map: "team_keeper_id_fkey")
   @@index([strikerId], map: "team_striker_id_fkey")
   @@index([userId], map: "team_user_id_fkey")
   @@map("team")
 }
+
 model record {
   userId String @id @map("user_id")
   score  Int    @default(1000) @map("score")
@@ -76,10 +84,14 @@ model record {
   draw   Int    @default(0) @map("draw")
   rank   Int    @map("rank")
   user   user   @relation(fields: [userId], references: [userId], onDelete: Cascade)
+
   @@map("record")
 }
+
 model matchHistory {
   matchId      Int      @id @default(autoincrement()) @map("match_id")
+  userIdA      String   @map("user_id_a")
+  userIdB      String   @map("user_id_b")
   teamIdA      Int      @map("team_id_a")
   teamIdB      Int      @map("team_id_b")
   resultA      String   @map("result_a")
@@ -89,41 +101,50 @@ model matchHistory {
   matchTime    DateTime @default(now()) @map("match_time")
   teamA        team     @relation("teamAMatches", fields: [teamIdA], references: [teamId])
   teamB        team     @relation("teamBMatches", fields: [teamIdB], references: [teamId])
+  userA        user     @relation("userMatches", fields: [userIdA], references: [userId])
+  userB        user     @relation("opponentMatches", fields: [userIdB], references: [userId])
 
   @@index([teamIdA], map: "match_history_team_id_a_fkey")
   @@index([teamIdB], map: "match_history_team_id_b_fkey")
+  @@index([userIdA], map: "match_history_user_id_a_fkey")
+  @@index([userIdB], map: "match_history_user_id_b_fkey")
   @@map("match_history")
 }
+
 model tournament {
-  tournamentId        Int               @id @unique(map: "tournament_id_UNIQUE") @default(autoincrement()) @map("tournament_id")
-  scheduledTime       DateTime          @db.DateTime(0) @map("scheduled_time")
-  winnerTeamId	      Int?				      @map("winner_team_id")
-  rewardPlayerId      Int				        @map("reward_player_id")
-  rewardPlayerGrade	  Int				        @map("reward_player_grade")
-  player              player            @relation(fields: [rewardPlayerId, rewardPlayerGrade], references: [playerId, grade], onDelete: NoAction, onUpdate: NoAction, map: "reward_player_id_fkey")
-  team                team?             @relation(fields: [winnerTeamId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "winner_team_id_fkey")
-  tournament_entry    tournamentEntry[]
-  tournament_match    tournamentMatch[]
-  @@index([rewardPlayerId, rewardPlayerGrade], map: "reward_player_id_fkey_idx")
-  @@index([winnerTeamId], map: "winner_team_id_fkey_idx")
+  tournament_id       Int                @id @unique(map: "tournament_id_UNIQUE") @default(autoincrement())
+  scheduled_time      DateTime           @db.DateTime(0)
+  winner_team_id      Int?
+  reward_player_id    Int
+  reward_player_grade Int
+  player              player             @relation(fields: [reward_player_id, reward_player_grade], references: [playerId, grade], onDelete: NoAction, onUpdate: NoAction, map: "reward_player_id_fkey")
+  team                team?              @relation(fields: [winner_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "winner_team_id_fkey")
+  tournament_entry    tournament_entry[]
+  tournament_match    tournament_match[]
+
+  @@index([reward_player_id, reward_player_grade], map: "reward_player_id_fkey_idx")
+  @@index([winner_team_id], map: "winner_team_id_fkey_idx")
 }
-model tournamentEntry {
-  tournamentEntryId   Int        @id @default(autoincrement())    @map("tournament_entry_id")
-  tournamentId        Int                                         @map("tournament_id")
-  teamId              Int		                                      @map("team_id")
-  ready               Int        @db.TinyInt    @default(0)        @map("ready")
-  tournament    tournament      @relation(fields: [tournamentId], references: [tournamentId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry_id_fkey")
-  team          team            @relation(fields: [teamId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "entry_team_id_fkey")
-  @@map("tournament_entry")
+
+model tournament_entry {
+  tournament_entry_id Int        @id @default(autoincrement())
+  tournament_id       Int
+  team_id             Int
+  ready               Int        @default(0) @db.TinyInt
+  team                team       @relation(fields: [team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "entry_team_id_fkey")
+  tournament          tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry_id_fkey")
+
+  @@index([team_id], map: "entry_team_id_fkey")
+  @@index([tournament_id], map: "tournament_entry_id_fkey")
 }
-model tournamentMatch {
-  tournamentMatchId   Int     @id   @default(autoincrement())   @map("tournament_match_id")
-  tournamentId        Int                                       @map("tournament_id")
-  roundName           String        @default("quater")          @map("roundName")
-  teamAId             Int                                       @map("teamA_id")
-  teamBId             Int                                       @map("teamB_id")
-  tournament    tournament      @relation(fields: [tournamentId], references: [tournamentId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
-  team_a        team            @relation("match_team_a", fields: [teamAId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "team_a_match_id_fkey")
-  team_b        team            @relation("match_team_b", fields: [teamBId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "team_b_match_id_fkey")
-  @@map("tournament_match")
+
+model tournament_match {
+  tournament_match_id Int        @id @default(autoincrement())
+  tournament_id       Int
+  roundName           String     @default("quater")
+  teamA_id            Int
+  teamB_id            Int
+  tournament          tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
+
+  @@index([tournament_id], map: "tournament_match_id_fkey")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,10 @@
 generator client {
   provider = "prisma-client-js"
 }
-
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
 }
-
 model user {
   userId        String         @id @map("user_id")
   userName      String         @unique @map("user_name")
@@ -17,10 +15,8 @@ model user {
   owningPlayer  owningPlayer[]
   record        record?
   team          team[]
-
   @@map("user")
 }
-
 model player {
   playerId     Int            @unique @default(autoincrement()) @map("player_id")
   playerName   String         @map("player_name")
@@ -32,11 +28,9 @@ model player {
   grade        Int            @default(1) @map("grade")
   owningPlayer owningPlayer[]
   tournament   tournament[]
-
   @@id([playerId, grade])
   @@map("player")
 }
-
 model owningPlayer {
   owningPlayerId Int    @id @default(autoincrement()) @map("owning_player_id")
   userId         String @map("user_id")
@@ -48,12 +42,10 @@ model owningPlayer {
   defender       team[] @relation("DefenderRelation")
   keeper         team[] @relation("KeeperRelation")
   striker        team[] @relation("StrikerRelation")
-
   @@index([playerId, grade], map: "owning_player_player_id_grade_fkey")
   @@index([userId], map: "owning_player_user_id_fkey")
   @@map("owning_player")
 }
-
 model team {
   teamId                                                         Int                @id @default(autoincrement()) @map("team_id")
   userId                                                         String             @map("user_id")
@@ -67,36 +59,15 @@ model team {
   striker                                                        owningPlayer       @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
   user                                                           user               @relation(fields: [userId], references: [userId], onDelete: Cascade)
   tournament                                                     tournament[]
-  tournament_entry_tournament_entry_entry1_team_idToteam         tournament_entry[] @relation("tournament_entry_entry1_team_idToteam")
-  tournament_entry_tournament_entry_entry2_team_idToteam         tournament_entry[] @relation("tournament_entry_entry2_team_idToteam")
-  tournament_entry_tournament_entry_entry3_team_idToteam         tournament_entry[] @relation("tournament_entry_entry3_team_idToteam")
-  tournament_entry_tournament_entry_entry4_team_idToteam         tournament_entry[] @relation("tournament_entry_entry4_team_idToteam")
-  tournament_entry_tournament_entry_entry5_team_idToteam         tournament_entry[] @relation("tournament_entry_entry5_team_idToteam")
-  tournament_entry_tournament_entry_entry6_team_idToteam         tournament_entry[] @relation("tournament_entry_entry6_team_idToteam")
-  tournament_entry_tournament_entry_entry7_team_idToteam         tournament_entry[] @relation("tournament_entry_entry7_team_idToteam")
-  tournament_entry_tournament_entry_entry8_team_idToteam         tournament_entry[] @relation("tournament_entry_entry8_team_idToteam")
-  tournament_match_tournament_match_final_user_a_team_idToteam   tournament_match[] @relation("tournament_match_final_user_a_team_idToteam")
-  tournament_match_tournament_match_final_user_b_team_idToteam   tournament_match[] @relation("tournament_match_final_user_b_team_idToteam")
-  tournament_match_tournament_match_quater1_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater1_user_a_team_idToteam")
-  tournament_match_tournament_match_quater1_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater1_user_b_team_idToteam")
-  tournament_match_tournament_match_quater2_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater2_user_a_team_idToteam")
-  tournament_match_tournament_match_quater2_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater2_user_b_team_idToteam")
-  tournament_match_tournament_match_quater3_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater3_user_a_team_idToteam")
-  tournament_match_tournament_match_quater3_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater3_user_b_team_idToteam")
-  tournament_match_tournament_match_quater4_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater4_user_a_team_idToteam")
-  tournament_match_tournament_match_quater4_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater4_user_b_team_idToteam")
-  tournament_match_tournament_match_semi1_user_a_team_idToteam   tournament_match[] @relation("tournament_match_semi1_user_a_team_idToteam")
-  tournament_match_tournament_match_semi1_user_b_team_idToteam   tournament_match[] @relation("tournament_match_semi1_user_b_team_idToteam")
-  tournament_match_tournament_match_semi2_user_a_team_idToteam   tournament_match[] @relation("tournament_match_semi2_user_a_team_idToteam")
-  tournament_match_tournament_match_semi2_user_b_team_idToteam   tournament_match[] @relation("tournament_match_semi2_user_b_team_idToteam")
-
+  tournamentEntry                                                tournamentEntry[]
+  team_entry_a        tournamentMatch[] @relation("match_team_a")
+  team_entry_b        tournamentMatch[] @relation("match_team_b")
   @@index([defenderId], map: "team_defender_id_fkey")
   @@index([keeperId], map: "team_keeper_id_fkey")
   @@index([strikerId], map: "team_striker_id_fkey")
   @@index([userId], map: "team_user_id_fkey")
   @@map("team")
 }
-
 model record {
   userId String @id @map("user_id")
   score  Int    @default(1000) @map("score")
@@ -105,14 +76,10 @@ model record {
   draw   Int    @default(0) @map("draw")
   rank   Int    @map("rank")
   user   user   @relation(fields: [userId], references: [userId], onDelete: Cascade)
-
   @@map("record")
 }
-
 model matchHistory {
   matchId      Int      @id @default(autoincrement()) @map("match_id")
-  userIdA      String   @map("user_id_a")
-  userIdB      String   @map("user_id_b")
   teamIdA      Int      @map("team_id_a")
   teamIdB      Int      @map("team_id_b")
   resultA      String   @map("result_a")
@@ -120,118 +87,43 @@ model matchHistory {
   scoreChangeA Int      @map("score_change_a")
   scoreChangeB Int      @map("score_change_b")
   matchTime    DateTime @default(now()) @map("match_time")
-  teamAScore   Int      @map("team_a_score")
-  teamBScore   Int      @map("team_b_score")
   teamA        team     @relation("teamAMatches", fields: [teamIdA], references: [teamId])
   teamB        team     @relation("teamBMatches", fields: [teamIdB], references: [teamId])
-  userA        user     @relation("userMatches", fields: [userIdA], references: [userId])
-  userB        user     @relation("opponentMatches", fields: [userIdB], references: [userId])
 
   @@index([teamIdA], map: "match_history_team_id_a_fkey")
   @@index([teamIdB], map: "match_history_team_id_b_fkey")
-  @@index([userIdA], map: "match_history_user_id_a_fkey")
-  @@index([userIdB], map: "match_history_user_id_b_fkey")
   @@map("match_history")
 }
-
 model tournament {
-  tournament_id       Int               @id @unique(map: "tournament_id_UNIQUE") @default(autoincrement())
-  scheduled_time      DateTime          @db.DateTime(0)
-  winner_team_id      Int?
-  reward_player_id    Int
-  reward_player_grade Int
-  player              player            @relation(fields: [reward_player_id, reward_player_grade], references: [playerId, grade], onDelete: NoAction, onUpdate: NoAction, map: "reward_player_id_fkey")
-  team                team?             @relation(fields: [winner_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "winner_team_id_fkey")
-  tournament_entry    tournament_entry?
-  tournament_match    tournament_match?
-
-  @@index([reward_player_id, reward_player_grade], map: "reward_player_id_fkey_idx")
-  @@index([winner_team_id], map: "winner_team_id_fkey_idx")
+  tournamentId        Int               @id @unique(map: "tournament_id_UNIQUE") @default(autoincrement()) @map("tournament_id")
+  scheduledTime       DateTime          @db.DateTime(0) @map("scheduled_time")
+  winnerTeamId	      Int?				      @map("winner_team_id")
+  rewardPlayerId      Int				        @map("reward_player_id")
+  rewardPlayerGrade	  Int				        @map("reward_player_grade")
+  player              player            @relation(fields: [rewardPlayerId, rewardPlayerGrade], references: [playerId, grade], onDelete: NoAction, onUpdate: NoAction, map: "reward_player_id_fkey")
+  team                team?             @relation(fields: [winnerTeamId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "winner_team_id_fkey")
+  tournament_entry    tournamentEntry[]
+  tournament_match    tournamentMatch[]
+  @@index([rewardPlayerId, rewardPlayerGrade], map: "reward_player_id_fkey_idx")
+  @@index([winnerTeamId], map: "winner_team_id_fkey_idx")
 }
-
-model tournament_entry {
-  tournament_id                              Int        @id @unique(map: "tournament_id_UNIQUE")
-  entry1_team_id                             Int?
-  entry2_team_id                             Int?
-  entry3_team_id                             Int?
-  entry4_team_id                             Int?
-  entry5_team_id                             Int?
-  entry6_team_id                             Int?
-  entry7_team_id                             Int?
-  entry8_team_id                             Int?
-  entry1_ready                               Int?       @db.TinyInt
-  entry2_ready                               Int?       @db.TinyInt
-  entry3_ready                               Int?       @db.TinyInt
-  entry4_ready                               Int?       @db.TinyInt
-  entry5_ready                               Int?       @db.TinyInt
-  entry6_ready                               Int?       @db.TinyInt
-  entry7_ready                               Int?       @db.TinyInt
-  entry8_ready                               Int?       @db.TinyInt
-  team_tournament_entry_entry1_team_idToteam team?      @relation("tournament_entry_entry1_team_idToteam", fields: [entry1_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry1_team_id_fkey")
-  team_tournament_entry_entry2_team_idToteam team?      @relation("tournament_entry_entry2_team_idToteam", fields: [entry2_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry2_team_id_fkey")
-  team_tournament_entry_entry3_team_idToteam team?      @relation("tournament_entry_entry3_team_idToteam", fields: [entry3_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry3_team_id_fkey")
-  team_tournament_entry_entry4_team_idToteam team?      @relation("tournament_entry_entry4_team_idToteam", fields: [entry4_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry4_team_id_fkey")
-  team_tournament_entry_entry5_team_idToteam team?      @relation("tournament_entry_entry5_team_idToteam", fields: [entry5_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry5_team_id_fkey")
-  team_tournament_entry_entry6_team_idToteam team?      @relation("tournament_entry_entry6_team_idToteam", fields: [entry6_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry6_team_id_fkey")
-  team_tournament_entry_entry7_team_idToteam team?      @relation("tournament_entry_entry7_team_idToteam", fields: [entry7_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry7_team_id_fkey")
-  team_tournament_entry_entry8_team_idToteam team?      @relation("tournament_entry_entry8_team_idToteam", fields: [entry8_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry8_team_id_fkey")
-  tournament                                 tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry_id_fkey")
-
-  @@index([entry1_team_id], map: "tournament_entry1_team_id_fkey_idx")
-  @@index([entry2_team_id], map: "tournament_entry2_team_id_fkey_idx")
-  @@index([entry3_team_id], map: "tournament_entry3_team_id_fkey_idx")
-  @@index([entry4_team_id], map: "tournament_entry4_team_id_fkey_idx")
-  @@index([entry5_team_id], map: "tournament_entry5_team_id_fkey_idx")
-  @@index([entry6_team_id], map: "tournament_entry6_team_id_fkey_idx")
-  @@index([entry7_team_id], map: "tournament_entry7_team_id_fkey_idx")
-  @@index([entry8_team_id], map: "tournament_entry8_team_id_fkey_idx")
+model tournamentEntry {
+  tournamentEntryId   Int        @id @default(autoincrement())    @map("tournament_entry_id")
+  tournamentId        Int                                         @map("tournament_id")
+  teamId              Int		                                      @map("team_id")
+  ready               Int        @db.TinyInt    @default(0)        @map("ready")
+  tournament    tournament      @relation(fields: [tournamentId], references: [tournamentId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry_id_fkey")
+  team          team            @relation(fields: [teamId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "entry_team_id_fkey")
+  @@map("tournament_entry")
 }
-
-model tournament_match {
-  tournament_id                                      Int        @id @unique(map: "tournament_id_UNIQUE")
-  quater1_user_a_team_id                             Int?
-  quater1_user_b_team_id                             Int?
-  quater2_user_a_team_id                             Int?
-  quater2_user_b_team_id                             Int?
-  quater3_user_a_team_id                             Int?
-  quater3_user_b_team_id                             Int?
-  quater4_user_a_team_id                             Int?
-  quater4_user_b_team_id                             Int?
-  semi1_user_a_team_id                               Int?
-  semi1_user_b_team_id                               Int?
-  semi2_user_a_team_id                               Int?
-  semi2_user_b_team_id                               Int?
-  final_user_a_team_id                               Int?
-  final_user_b_team_id                               Int?
-  team_tournament_match_final_user_a_team_idToteam   team?      @relation("tournament_match_final_user_a_team_idToteam", fields: [final_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_f_a_team_id_fkey")
-  team_tournament_match_final_user_b_team_idToteam   team?      @relation("tournament_match_final_user_b_team_idToteam", fields: [final_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_f_b_team_id_fkey")
-  tournament                                         tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
-  team_tournament_match_quater1_user_a_team_idToteam team?      @relation("tournament_match_quater1_user_a_team_idToteam", fields: [quater1_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q1_a_team_id_fkey")
-  team_tournament_match_quater1_user_b_team_idToteam team?      @relation("tournament_match_quater1_user_b_team_idToteam", fields: [quater1_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q1_b_team_id_fkey")
-  team_tournament_match_quater2_user_a_team_idToteam team?      @relation("tournament_match_quater2_user_a_team_idToteam", fields: [quater2_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q2_a_team_id_fkey")
-  team_tournament_match_quater2_user_b_team_idToteam team?      @relation("tournament_match_quater2_user_b_team_idToteam", fields: [quater2_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q2_b_team_id_fkey")
-  team_tournament_match_quater3_user_a_team_idToteam team?      @relation("tournament_match_quater3_user_a_team_idToteam", fields: [quater3_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q3_a_team_id_fkey")
-  team_tournament_match_quater3_user_b_team_idToteam team?      @relation("tournament_match_quater3_user_b_team_idToteam", fields: [quater3_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q3_b_team_id_fkey")
-  team_tournament_match_quater4_user_a_team_idToteam team?      @relation("tournament_match_quater4_user_a_team_idToteam", fields: [quater4_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q4_a_team_id_fkey")
-  team_tournament_match_quater4_user_b_team_idToteam team?      @relation("tournament_match_quater4_user_b_team_idToteam", fields: [quater4_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q4_b_team_id_fkey")
-  team_tournament_match_semi1_user_a_team_idToteam   team?      @relation("tournament_match_semi1_user_a_team_idToteam", fields: [semi1_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s1_a_team_id_fkey")
-  team_tournament_match_semi1_user_b_team_idToteam   team?      @relation("tournament_match_semi1_user_b_team_idToteam", fields: [semi1_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s1_b_team_id_fkey")
-  team_tournament_match_semi2_user_a_team_idToteam   team?      @relation("tournament_match_semi2_user_a_team_idToteam", fields: [semi2_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s2_a_team_id_fkey")
-  team_tournament_match_semi2_user_b_team_idToteam   team?      @relation("tournament_match_semi2_user_b_team_idToteam", fields: [semi2_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s2_b_team_id_fkey")
-
-  @@index([final_user_a_team_id], map: "tournament_match_f_a_team_id_fkey_idx")
-  @@index([final_user_b_team_id], map: "tournament_match_f_b_team_id_fkey_idx")
-  @@index([quater1_user_a_team_id], map: "tournament_match_q1_a_team_id_fkey_idx")
-  @@index([quater1_user_b_team_id], map: "tournament_match_q1_b_team_id_fkey_idx")
-  @@index([quater2_user_a_team_id], map: "tournament_match_q2_a_team_id_fkey_idx")
-  @@index([quater2_user_b_team_id], map: "tournament_match_q2_b_team_id_fkey_idx")
-  @@index([quater3_user_a_team_id], map: "tournament_match_q3_a_team_id_fkey_idx")
-  @@index([quater3_user_b_team_id], map: "tournament_match_q3_b_team_id_fkey_idx")
-  @@index([quater4_user_a_team_id], map: "tournament_match_q4_a_team_id_fkey_idx")
-  @@index([quater4_user_b_team_id], map: "tournament_match_q4_b_team_id_fkey_idx")
-  @@index([semi1_user_a_team_id], map: "tournament_match_s1_a_team_id_fkey_idx")
-  @@index([semi1_user_b_team_id], map: "tournament_match_s1_b_team_id_fkey_idx")
-  @@index([semi2_user_a_team_id], map: "tournament_match_s2_a_team_id_fkey_idx")
-  @@index([semi2_user_b_team_id], map: "tournament_match_s2_b_team_id_fkey_idx")
-  @@index([quater1_user_a_team_id, quater1_user_b_team_id, quater2_user_a_team_id, quater2_user_b_team_id, quater3_user_a_team_id, quater3_user_b_team_id, quater4_user_a_team_id, quater4_user_b_team_id, semi1_user_a_team_id, semi1_user_b_team_id, semi2_user_a_team_id, semi2_user_b_team_id, final_user_a_team_id, final_user_b_team_id], map: "tournament_match_team_id_fkey_idx")
+model tournamentMatch {
+  tournamentMatchId   Int     @id   @default(autoincrement())   @map("tournament_match_id")
+  tournamentId        Int                                       @map("tournament_id")
+  roundName           String        @default("quater")          @map("roundName")
+  teamAId             Int                                       @map("teamA_id")
+  teamBId             Int                                       @map("teamB_id")
+  tournament    tournament      @relation(fields: [tournamentId], references: [tournamentId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
+  team_a        team            @relation("match_team_a", fields: [teamAId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "team_a_match_id_fkey")
+  team_b        team            @relation("match_team_b", fields: [teamBId], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "team_b_match_id_fkey")
+  @@map("tournament_match")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,19 +55,21 @@ model owningPlayer {
 }
 
 model team {
-  teamId           Int                @id @default(autoincrement()) @map("team_id")
-  userId           String             @map("user_id")
-  defenderId       Int                @map("defender_id")
-  strikerId        Int                @map("striker_id")
-  keeperId         Int                @map("keeper_id")
-  matchHistoryAsA  matchHistory[]     @relation("teamAMatches")
-  matchHistoryAsB  matchHistory[]     @relation("teamBMatches")
-  defender         owningPlayer       @relation("DefenderRelation", fields: [defenderId], references: [owningPlayerId], onDelete: Cascade)
-  keeper           owningPlayer       @relation("KeeperRelation", fields: [keeperId], references: [owningPlayerId], onDelete: Cascade)
-  striker          owningPlayer       @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
-  user             user               @relation(fields: [userId], references: [userId], onDelete: Cascade)
-  tournament       tournament[]
-  tournament_entry tournament_entry[]
+  teamId                                           Int                @id @default(autoincrement()) @map("team_id")
+  userId                                           String             @map("user_id")
+  defenderId                                       Int                @map("defender_id")
+  strikerId                                        Int                @map("striker_id")
+  keeperId                                         Int                @map("keeper_id")
+  matchHistoryAsA                                  matchHistory[]     @relation("teamAMatches")
+  matchHistoryAsB                                  matchHistory[]     @relation("teamBMatches")
+  defender                                         owningPlayer       @relation("DefenderRelation", fields: [defenderId], references: [owningPlayerId], onDelete: Cascade)
+  keeper                                           owningPlayer       @relation("KeeperRelation", fields: [keeperId], references: [owningPlayerId], onDelete: Cascade)
+  striker                                          owningPlayer       @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
+  user                                             user               @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  tournament                                       tournament[]
+  tournament_entry                                 tournament_entry[]
+  tournament_match_tournament_match_teamA_idToteam tournament_match[] @relation("tournament_match_teamA_idToteam")
+  tournament_match_tournament_match_teamB_idToteam tournament_match[] @relation("tournament_match_teamB_idToteam")
 
   @@index([defenderId], map: "team_defender_id_fkey")
   @@index([keeperId], map: "team_keeper_id_fkey")
@@ -139,12 +141,16 @@ model tournament_entry {
 }
 
 model tournament_match {
-  tournament_match_id Int        @id @default(autoincrement())
-  tournament_id       Int
-  roundName           String     @default("quater")
-  teamA_id            Int
-  teamB_id            Int
-  tournament          tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
+  tournament_match_id                  Int        @id @default(autoincrement())
+  tournament_id                        Int
+  roundName                            String     @default("quater")
+  teamA_id                             Int
+  teamB_id                             Int
+  team_tournament_match_teamA_idToteam team       @relation("tournament_match_teamA_idToteam", fields: [teamA_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "team_a_match_id_fkey")
+  team_tournament_match_teamB_idToteam team       @relation("tournament_match_teamB_idToteam", fields: [teamB_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "team_b_match_id_fkey")
+  tournament                           tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
 
   @@index([tournament_id], map: "tournament_match_id_fkey")
+  @@index([teamA_id], map: "team_a_match_id_fkey")
+  @@index([teamB_id], map: "team_b_match_id_fkey")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,101 +8,230 @@ datasource db {
 }
 
 model user {
-  userId   String      @id                 @map("user_id")
-  userName String      @unique             @map("user_name")
-  userPw   String                          @map("user_pw")
-  cash      Int         @default(10000)     @map("cash")
-
-  team      team[]
-  owningPlayer owningPlayer[]
-  record    record?
+  userId        String         @id @map("user_id")
+  userName      String         @unique @map("user_name")
+  userPw        String         @map("user_pw")
+  cash          Int            @default(10000) @map("cash")
   matchHistoryA matchHistory[] @relation("userMatches")
   matchHistoryB matchHistory[] @relation("opponentMatches")
+  owningPlayer  owningPlayer[]
+  record        record?
+  team          team[]
 
   @@map("user")
 }
 
 model player {
-  playerId         Int        @default(autoincrement())   @map("player_id")
-  playerName       String                                 @map("player_name")
-  speed            Int                                    @map("speed")
-  goalDecision     Int                                    @map("goal_decision")
-  shootPower       Int                                    @map("shoot_power")
-  defence          Int                                    @map("defence")
-  stamina          Int                                    @map("stamina")
-  grade            Int         @default(1)                @map("grade")
+  playerId     Int            @unique @default(autoincrement()) @map("player_id")
+  playerName   String         @map("player_name")
+  speed        Int            @map("speed")
+  goalDecision Int            @map("goal_decision")
+  shootPower   Int            @map("shoot_power")
+  defence      Int            @map("defence")
+  stamina      Int            @map("stamina")
+  grade        Int            @default(1) @map("grade")
+  owningPlayer owningPlayer[]
+  tournament   tournament[]
 
   @@id([playerId, grade])
-
-  owningPlayer       owningPlayer[]
-  
   @@map("player")
 }
 
 model owningPlayer {
-  owningPlayerId    Int     @id @default(autoincrement())    @map("owning_player_id")
-  userId            String                                   @map("user_id")
-  playerId          Int                                      @map("player_id")
-  grade             Int                                      @map("grade")
-  count             Int         @default(1)                  @map("count")
+  owningPlayerId Int    @id @default(autoincrement()) @map("owning_player_id")
+  userId         String @map("user_id")
+  playerId       Int    @map("player_id")
+  grade          Int    @map("grade")
+  count          Int    @default(1) @map("count")
+  player         player @relation(fields: [playerId, grade], references: [playerId, grade], onDelete: Cascade)
+  user           user   @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  defender       team[] @relation("DefenderRelation")
+  keeper         team[] @relation("KeeperRelation")
+  striker        team[] @relation("StrikerRelation")
 
-  user user  @relation(fields: [userId], references: [userId], onDelete: Cascade)
-  player player @relation(fields: [playerId, grade], references: [playerId, grade], onDelete: Cascade)
-
-  defender        team[]        @relation("DefenderRelation")
-  striker         team[]        @relation("StrikerRelation")
-  keeper          team[]        @relation("KeeperRelation")
-
+  @@index([playerId, grade], map: "owning_player_player_id_grade_fkey")
+  @@index([userId], map: "owning_player_user_id_fkey")
   @@map("owning_player")
 }
 
 model team {
-  teamId      Int     @id @default(autoincrement())     @map("team_id")
-  userId      String                                    @map("user_id")
-  defenderId  Int                                       @map("defender_id")
-  strikerId   Int                                       @map("striker_id")
-  keeperId    Int                                       @map("keeper_id")
+  teamId                                                         Int                @id @default(autoincrement()) @map("team_id")
+  userId                                                         String             @map("user_id")
+  defenderId                                                     Int                @map("defender_id")
+  strikerId                                                      Int                @map("striker_id")
+  keeperId                                                       Int                @map("keeper_id")
+  matchHistoryAsA                                                matchHistory[]     @relation("teamAMatches")
+  matchHistoryAsB                                                matchHistory[]     @relation("teamBMatches")
+  defender                                                       owningPlayer       @relation("DefenderRelation", fields: [defenderId], references: [owningPlayerId], onDelete: Cascade)
+  keeper                                                         owningPlayer       @relation("KeeperRelation", fields: [keeperId], references: [owningPlayerId], onDelete: Cascade)
+  striker                                                        owningPlayer       @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
+  user                                                           user               @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  tournament                                                     tournament[]
+  tournament_entry_tournament_entry_entry1_team_idToteam         tournament_entry[] @relation("tournament_entry_entry1_team_idToteam")
+  tournament_entry_tournament_entry_entry2_team_idToteam         tournament_entry[] @relation("tournament_entry_entry2_team_idToteam")
+  tournament_entry_tournament_entry_entry3_team_idToteam         tournament_entry[] @relation("tournament_entry_entry3_team_idToteam")
+  tournament_entry_tournament_entry_entry4_team_idToteam         tournament_entry[] @relation("tournament_entry_entry4_team_idToteam")
+  tournament_entry_tournament_entry_entry5_team_idToteam         tournament_entry[] @relation("tournament_entry_entry5_team_idToteam")
+  tournament_entry_tournament_entry_entry6_team_idToteam         tournament_entry[] @relation("tournament_entry_entry6_team_idToteam")
+  tournament_entry_tournament_entry_entry7_team_idToteam         tournament_entry[] @relation("tournament_entry_entry7_team_idToteam")
+  tournament_entry_tournament_entry_entry8_team_idToteam         tournament_entry[] @relation("tournament_entry_entry8_team_idToteam")
+  tournament_match_tournament_match_final_user_a_team_idToteam   tournament_match[] @relation("tournament_match_final_user_a_team_idToteam")
+  tournament_match_tournament_match_final_user_b_team_idToteam   tournament_match[] @relation("tournament_match_final_user_b_team_idToteam")
+  tournament_match_tournament_match_quater1_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater1_user_a_team_idToteam")
+  tournament_match_tournament_match_quater1_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater1_user_b_team_idToteam")
+  tournament_match_tournament_match_quater2_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater2_user_a_team_idToteam")
+  tournament_match_tournament_match_quater2_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater2_user_b_team_idToteam")
+  tournament_match_tournament_match_quater3_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater3_user_a_team_idToteam")
+  tournament_match_tournament_match_quater3_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater3_user_b_team_idToteam")
+  tournament_match_tournament_match_quater4_user_a_team_idToteam tournament_match[] @relation("tournament_match_quater4_user_a_team_idToteam")
+  tournament_match_tournament_match_quater4_user_b_team_idToteam tournament_match[] @relation("tournament_match_quater4_user_b_team_idToteam")
+  tournament_match_tournament_match_semi1_user_a_team_idToteam   tournament_match[] @relation("tournament_match_semi1_user_a_team_idToteam")
+  tournament_match_tournament_match_semi1_user_b_team_idToteam   tournament_match[] @relation("tournament_match_semi1_user_b_team_idToteam")
+  tournament_match_tournament_match_semi2_user_a_team_idToteam   tournament_match[] @relation("tournament_match_semi2_user_a_team_idToteam")
+  tournament_match_tournament_match_semi2_user_b_team_idToteam   tournament_match[] @relation("tournament_match_semi2_user_b_team_idToteam")
 
-  user user  @relation(fields: [userId], references: [userId], onDelete: Cascade)
-  defender owningPlayer @relation("DefenderRelation", fields: [defenderId], references: [owningPlayerId], onDelete: Cascade)
-  striker owningPlayer @relation("StrikerRelation", fields: [strikerId], references: [owningPlayerId], onDelete: Cascade)
-  keeper owningPlayer @relation("KeeperRelation", fields: [keeperId], references: [owningPlayerId], onDelete: Cascade)
-
-  matchHistoryAsA matchHistory[] @relation("teamAMatches")
-  matchHistoryAsB matchHistory[] @relation("teamBMatches")
-
+  @@index([defenderId], map: "team_defender_id_fkey")
+  @@index([keeperId], map: "team_keeper_id_fkey")
+  @@index([strikerId], map: "team_striker_id_fkey")
+  @@index([userId], map: "team_user_id_fkey")
   @@map("team")
 }
 
 model record {
-  userId   String   @id              @map("user_id")
-  score     Int     @default(1000)   @map("score")
-  win       Int     @default(0)      @map("win")
-  lose      Int     @default(0)      @map("lose")
-  draw      Int     @default(0)      @map("draw")
-  rank      Int                      @map("rank")
-  
-  user user  @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  userId String @id @map("user_id")
+  score  Int    @default(1000) @map("score")
+  win    Int    @default(0) @map("win")
+  lose   Int    @default(0) @map("lose")
+  draw   Int    @default(0) @map("draw")
+  rank   Int    @map("rank")
+  user   user   @relation(fields: [userId], references: [userId], onDelete: Cascade)
 
   @@map("record")
 }
 
 model matchHistory {
-  matchId       Int      @id @default(autoincrement()) @map("match_id")
-  userIdA       String                                @map("user_id_a")
-  userIdB       String                                @map("user_id_b")
-  teamIdA       Int                                   @map("team_id_a")
-  teamIdB       Int                                   @map("team_id_b")
-  resultA       String                                @map("result_a")
-  resultB       String                                @map("result_b")
-  scoreChangeA  Int                                   @map("score_change_a")
-  scoreChangeB  Int                                   @map("score_change_b")
-  matchTime     DateTime @default(now())              @map("match_time")
+  matchId      Int      @id @default(autoincrement()) @map("match_id")
+  userIdA      String   @map("user_id_a")
+  userIdB      String   @map("user_id_b")
+  teamIdA      Int      @map("team_id_a")
+  teamIdB      Int      @map("team_id_b")
+  resultA      String   @map("result_a")
+  resultB      String   @map("result_b")
+  scoreChangeA Int      @map("score_change_a")
+  scoreChangeB Int      @map("score_change_b")
+  matchTime    DateTime @default(now()) @map("match_time")
+  teamAScore   Int      @map("team_a_score")
+  teamBScore   Int      @map("team_b_score")
+  teamA        team     @relation("teamAMatches", fields: [teamIdA], references: [teamId])
+  teamB        team     @relation("teamBMatches", fields: [teamIdB], references: [teamId])
+  userA        user     @relation("userMatches", fields: [userIdA], references: [userId])
+  userB        user     @relation("opponentMatches", fields: [userIdB], references: [userId])
 
-  userA user @relation("userMatches", fields: [userIdA], references: [userId])
-  userB user @relation("opponentMatches", fields: [userIdB], references: [userId])
-  teamA team @relation("teamAMatches", fields: [teamIdA], references: [teamId])
-  teamB team @relation("teamBMatches", fields: [teamIdB], references: [teamId])
-
+  @@index([teamIdA], map: "match_history_team_id_a_fkey")
+  @@index([teamIdB], map: "match_history_team_id_b_fkey")
+  @@index([userIdA], map: "match_history_user_id_a_fkey")
+  @@index([userIdB], map: "match_history_user_id_b_fkey")
   @@map("match_history")
+}
+
+model tournament {
+  tournament_id       Int               @id @unique(map: "tournament_id_UNIQUE") @default(autoincrement())
+  scheduled_time      DateTime          @db.DateTime(0)
+  winner_team_id      Int?
+  reward_player_id    Int
+  reward_player_grade Int
+  player              player            @relation(fields: [reward_player_id, reward_player_grade], references: [playerId, grade], onDelete: NoAction, onUpdate: NoAction, map: "reward_player_id_fkey")
+  team                team?             @relation(fields: [winner_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "winner_team_id_fkey")
+  tournament_entry    tournament_entry?
+  tournament_match    tournament_match?
+
+  @@index([reward_player_id, reward_player_grade], map: "reward_player_id_fkey_idx")
+  @@index([winner_team_id], map: "winner_team_id_fkey_idx")
+}
+
+model tournament_entry {
+  tournament_id                              Int        @id @unique(map: "tournament_id_UNIQUE")
+  entry1_team_id                             Int?
+  entry2_team_id                             Int?
+  entry3_team_id                             Int?
+  entry4_team_id                             Int?
+  entry5_team_id                             Int?
+  entry6_team_id                             Int?
+  entry7_team_id                             Int?
+  entry8_team_id                             Int?
+  entry1_ready                               Int?       @db.TinyInt
+  entry2_ready                               Int?       @db.TinyInt
+  entry3_ready                               Int?       @db.TinyInt
+  entry4_ready                               Int?       @db.TinyInt
+  entry5_ready                               Int?       @db.TinyInt
+  entry6_ready                               Int?       @db.TinyInt
+  entry7_ready                               Int?       @db.TinyInt
+  entry8_ready                               Int?       @db.TinyInt
+  team_tournament_entry_entry1_team_idToteam team?      @relation("tournament_entry_entry1_team_idToteam", fields: [entry1_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry1_team_id_fkey")
+  team_tournament_entry_entry2_team_idToteam team?      @relation("tournament_entry_entry2_team_idToteam", fields: [entry2_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry2_team_id_fkey")
+  team_tournament_entry_entry3_team_idToteam team?      @relation("tournament_entry_entry3_team_idToteam", fields: [entry3_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry3_team_id_fkey")
+  team_tournament_entry_entry4_team_idToteam team?      @relation("tournament_entry_entry4_team_idToteam", fields: [entry4_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry4_team_id_fkey")
+  team_tournament_entry_entry5_team_idToteam team?      @relation("tournament_entry_entry5_team_idToteam", fields: [entry5_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry5_team_id_fkey")
+  team_tournament_entry_entry6_team_idToteam team?      @relation("tournament_entry_entry6_team_idToteam", fields: [entry6_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry6_team_id_fkey")
+  team_tournament_entry_entry7_team_idToteam team?      @relation("tournament_entry_entry7_team_idToteam", fields: [entry7_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry7_team_id_fkey")
+  team_tournament_entry_entry8_team_idToteam team?      @relation("tournament_entry_entry8_team_idToteam", fields: [entry8_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry8_team_id_fkey")
+  tournament                                 tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_entry_id_fkey")
+
+  @@index([entry1_team_id], map: "tournament_entry1_team_id_fkey_idx")
+  @@index([entry2_team_id], map: "tournament_entry2_team_id_fkey_idx")
+  @@index([entry3_team_id], map: "tournament_entry3_team_id_fkey_idx")
+  @@index([entry4_team_id], map: "tournament_entry4_team_id_fkey_idx")
+  @@index([entry5_team_id], map: "tournament_entry5_team_id_fkey_idx")
+  @@index([entry6_team_id], map: "tournament_entry6_team_id_fkey_idx")
+  @@index([entry7_team_id], map: "tournament_entry7_team_id_fkey_idx")
+  @@index([entry8_team_id], map: "tournament_entry8_team_id_fkey_idx")
+}
+
+model tournament_match {
+  tournament_id                                      Int        @id @unique(map: "tournament_id_UNIQUE")
+  quater1_user_a_team_id                             Int?
+  quater1_user_b_team_id                             Int?
+  quater2_user_a_team_id                             Int?
+  quater2_user_b_team_id                             Int?
+  quater3_user_a_team_id                             Int?
+  quater3_user_b_team_id                             Int?
+  quater4_user_a_team_id                             Int?
+  quater4_user_b_team_id                             Int?
+  semi1_user_a_team_id                               Int?
+  semi1_user_b_team_id                               Int?
+  semi2_user_a_team_id                               Int?
+  semi2_user_b_team_id                               Int?
+  final_user_a_team_id                               Int?
+  final_user_b_team_id                               Int?
+  team_tournament_match_final_user_a_team_idToteam   team?      @relation("tournament_match_final_user_a_team_idToteam", fields: [final_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_f_a_team_id_fkey")
+  team_tournament_match_final_user_b_team_idToteam   team?      @relation("tournament_match_final_user_b_team_idToteam", fields: [final_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_f_b_team_id_fkey")
+  tournament                                         tournament @relation(fields: [tournament_id], references: [tournament_id], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_id_fkey")
+  team_tournament_match_quater1_user_a_team_idToteam team?      @relation("tournament_match_quater1_user_a_team_idToteam", fields: [quater1_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q1_a_team_id_fkey")
+  team_tournament_match_quater1_user_b_team_idToteam team?      @relation("tournament_match_quater1_user_b_team_idToteam", fields: [quater1_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q1_b_team_id_fkey")
+  team_tournament_match_quater2_user_a_team_idToteam team?      @relation("tournament_match_quater2_user_a_team_idToteam", fields: [quater2_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q2_a_team_id_fkey")
+  team_tournament_match_quater2_user_b_team_idToteam team?      @relation("tournament_match_quater2_user_b_team_idToteam", fields: [quater2_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q2_b_team_id_fkey")
+  team_tournament_match_quater3_user_a_team_idToteam team?      @relation("tournament_match_quater3_user_a_team_idToteam", fields: [quater3_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q3_a_team_id_fkey")
+  team_tournament_match_quater3_user_b_team_idToteam team?      @relation("tournament_match_quater3_user_b_team_idToteam", fields: [quater3_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q3_b_team_id_fkey")
+  team_tournament_match_quater4_user_a_team_idToteam team?      @relation("tournament_match_quater4_user_a_team_idToteam", fields: [quater4_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q4_a_team_id_fkey")
+  team_tournament_match_quater4_user_b_team_idToteam team?      @relation("tournament_match_quater4_user_b_team_idToteam", fields: [quater4_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_q4_b_team_id_fkey")
+  team_tournament_match_semi1_user_a_team_idToteam   team?      @relation("tournament_match_semi1_user_a_team_idToteam", fields: [semi1_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s1_a_team_id_fkey")
+  team_tournament_match_semi1_user_b_team_idToteam   team?      @relation("tournament_match_semi1_user_b_team_idToteam", fields: [semi1_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s1_b_team_id_fkey")
+  team_tournament_match_semi2_user_a_team_idToteam   team?      @relation("tournament_match_semi2_user_a_team_idToteam", fields: [semi2_user_a_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s2_a_team_id_fkey")
+  team_tournament_match_semi2_user_b_team_idToteam   team?      @relation("tournament_match_semi2_user_b_team_idToteam", fields: [semi2_user_b_team_id], references: [teamId], onDelete: NoAction, onUpdate: NoAction, map: "tournament_match_s2_b_team_id_fkey")
+
+  @@index([final_user_a_team_id], map: "tournament_match_f_a_team_id_fkey_idx")
+  @@index([final_user_b_team_id], map: "tournament_match_f_b_team_id_fkey_idx")
+  @@index([quater1_user_a_team_id], map: "tournament_match_q1_a_team_id_fkey_idx")
+  @@index([quater1_user_b_team_id], map: "tournament_match_q1_b_team_id_fkey_idx")
+  @@index([quater2_user_a_team_id], map: "tournament_match_q2_a_team_id_fkey_idx")
+  @@index([quater2_user_b_team_id], map: "tournament_match_q2_b_team_id_fkey_idx")
+  @@index([quater3_user_a_team_id], map: "tournament_match_q3_a_team_id_fkey_idx")
+  @@index([quater3_user_b_team_id], map: "tournament_match_q3_b_team_id_fkey_idx")
+  @@index([quater4_user_a_team_id], map: "tournament_match_q4_a_team_id_fkey_idx")
+  @@index([quater4_user_b_team_id], map: "tournament_match_q4_b_team_id_fkey_idx")
+  @@index([semi1_user_a_team_id], map: "tournament_match_s1_a_team_id_fkey_idx")
+  @@index([semi1_user_b_team_id], map: "tournament_match_s1_b_team_id_fkey_idx")
+  @@index([semi2_user_a_team_id], map: "tournament_match_s2_a_team_id_fkey_idx")
+  @@index([semi2_user_b_team_id], map: "tournament_match_s2_b_team_id_fkey_idx")
+  @@index([quater1_user_a_team_id, quater1_user_b_team_id, quater2_user_a_team_id, quater2_user_b_team_id, quater3_user_a_team_id, quater3_user_b_team_id, quater4_user_a_team_id, quater4_user_b_team_id, semi1_user_a_team_id, semi1_user_b_team_id, semi2_user_a_team_id, semi2_user_b_team_id, final_user_a_team_id, final_user_b_team_id], map: "tournament_match_team_id_fkey_idx")
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,19 +1,30 @@
 import express from 'express';
-import rankingRouter from './routes/ranking.router.js';
 import cookieParser from 'cookie-parser';
 import dotEnv from 'dotenv';
 import errorHandlerMiddleware from './middlewares/error-handler.middleware.js';
+import rankingRouter from './routes/ranking.router.js';
 import gamePlayRouter from './routes/game-play.router.js';
 import userRouter from './routes/user.router.js';
 import owningPlayerRouter from './routes/owning_player.router.js';
 import teamRouter from './routes/team.router.js';
 import matchHistoryRouter from './routes/match-history.router.js';
 
+dotEnv.config();
 
 const app = express();
 app.use(express.json());
 app.use(cookieParser());
-app.use('/api', [gamePlayRouter, userRouter, owningPlayerRouter, teamRouter, rankingRouter, matchHistoryRouter]);
+
+const routers = [
+  gamePlayRouter,
+  userRouter,
+  owningPlayerRouter,
+  teamRouter,
+  rankingRouter,
+  matchHistoryRouter
+];
+
+app.use('/api', routers);
 app.use(errorHandlerMiddleware);
 
 const PORT = process.env.PORT || 3000;

--- a/src/logics/match-history.logic.js
+++ b/src/logics/match-history.logic.js
@@ -5,8 +5,6 @@ export const getMatchHistory = async (req, res, next) => {
   try {
     const { userId } = req.params;
 
-    console.log("Fetching match history for userId:", userId);  // 로깅 추가
-
     // 해당 유저의 경기 기록을 조회
     const matches = await prisma.matchHistory.findMany({
       where: {
@@ -38,12 +36,14 @@ export const getMatchHistory = async (req, res, next) => {
       resultB: match.resultB,
       scoreChangeA: match.scoreChangeA,
       scoreChangeB: match.scoreChangeB,
+      teamAScore: match.teamAScore,  
+      teamBScore: match.teamBScore,
       matchTime: match.matchTime
     }));
 
     res.json({ matches: formattedMatches });
   } catch (error) {
-    console.error("Error fetching match history:", error);  // 에러 로그 잡기 
+    console.error(" 오류가 발생했습니다 ! :", error);  // 에러 로그 잡기 
     next(error);
   }
 };

--- a/src/logics/match-history.logic.js
+++ b/src/logics/match-history.logic.js
@@ -7,7 +7,9 @@ export const getMatchHistory = async (req, res, next) => {
 
     // 해당 유저의 팀 정보를 조회
     const userTeams = await prisma.team.findMany({
-      where: { userId: userId },
+      where: {
+        userId: userId,
+      },
     });
 
     // 팀 ID 추출
@@ -24,21 +26,25 @@ export const getMatchHistory = async (req, res, next) => {
       include: {
         teamA: true,
         teamB: true,
+        userA: true,
+        userB: true,
       },
-      orderBy: { matchTime: 'desc' }
+      orderBy: {
+        matchTime: 'desc'
+      }
     });
 
-    console.log("Matches found:", matches);
+    console.log("Matches found:", matches);  // 로깅 추가
 
     // 각 팀의 기록을 조회하여 점수 변동을 실시간 반영
     const formattedMatches = await Promise.all(matches.map(async (match) => {
       const teamAScore = await prisma.record.findUnique({
-        where: { userId: match.teamA.userId },
+        where: { userId: match.userIdA },
         select: { score: true }
       });
 
       const teamBScore = await prisma.record.findUnique({
-        where: { userId: match.teamB.userId },
+        where: { userId: match.userIdB },
         select: { score: true }
       });
 
@@ -49,7 +55,7 @@ export const getMatchHistory = async (req, res, next) => {
         resultB: match.resultB,
         scoreChangeA: match.scoreChangeA,
         scoreChangeB: match.scoreChangeB,
-        teamAScore: teamAScore.score,
+        teamAScore: teamAScore.score,  
         teamBScore: teamBScore.score,
         matchTime: match.matchTime
       };
@@ -57,7 +63,7 @@ export const getMatchHistory = async (req, res, next) => {
 
     res.json({ matches: formattedMatches });
   } catch (error) {
-    console.error(" 오류가 발생했습니다 ! :", error);
+    console.error(" 오류가 발생했습니다 ! :", error);  // 에러 로그 잡기 
     next(error);
   }
 };

--- a/src/logics/match-history.logic.js
+++ b/src/logics/match-history.logic.js
@@ -5,45 +5,59 @@ export const getMatchHistory = async (req, res, next) => {
   try {
     const { userId } = req.params;
 
+    // 해당 유저의 팀 정보를 조회
+    const userTeams = await prisma.team.findMany({
+      where: { userId: userId },
+    });
+
+    // 팀 ID 추출
+    const teamIds = userTeams.map(team => team.teamId);
+
     // 해당 유저의 경기 기록을 조회
     const matches = await prisma.matchHistory.findMany({
       where: {
         OR: [
-          { userIdA: userId },
-          { userIdB: userId }
+          { teamIdA: { in: teamIds } },
+          { teamIdB: { in: teamIds } }
         ]
       },
       include: {
-        userA: true,
-        userB: true,
         teamA: true,
-        teamB: true
+        teamB: true,
       },
-      orderBy: {
-        matchTime: 'desc'
-      }
+      orderBy: { matchTime: 'desc' }
     });
 
-    console.log("Matches found:", matches);  // 로깅 추가
+    console.log("Matches found:", matches);
 
-    // 조회된 경기 기록을 포맷
-    const formattedMatches = matches.map(match => ({
-      userIdA: match.userIdA,
-      userIdB: match.userIdB,
-      teamIdA: match.teamIdA,
-      teamIdB: match.teamIdB,
-      resultA: match.resultA,
-      resultB: match.resultB,
-      scoreChangeA: match.scoreChangeA,
-      scoreChangeB: match.scoreChangeB,
-      teamAScore: match.teamAScore,  
-      teamBScore: match.teamBScore,
-      matchTime: match.matchTime
+    // 각 팀의 기록을 조회하여 점수 변동을 실시간 반영
+    const formattedMatches = await Promise.all(matches.map(async (match) => {
+      const teamAScore = await prisma.record.findUnique({
+        where: { userId: match.teamA.userId },
+        select: { score: true }
+      });
+
+      const teamBScore = await prisma.record.findUnique({
+        where: { userId: match.teamB.userId },
+        select: { score: true }
+      });
+
+      return {
+        teamIdA: match.teamIdA,
+        teamIdB: match.teamIdB,
+        resultA: match.resultA,
+        resultB: match.resultB,
+        scoreChangeA: match.scoreChangeA,
+        scoreChangeB: match.scoreChangeB,
+        teamAScore: teamAScore.score,
+        teamBScore: teamBScore.score,
+        matchTime: match.matchTime
+      };
     }));
 
     res.json({ matches: formattedMatches });
   } catch (error) {
-    console.error(" 오류가 발생했습니다 ! :", error);  // 에러 로그 잡기 
+    console.error(" 오류가 발생했습니다 ! :", error);
     next(error);
   }
 };

--- a/src/logics/ranking.logic.js
+++ b/src/logics/ranking.logic.js
@@ -19,7 +19,7 @@ export const getRankings = async (req, res, next) => {
 
     res.json({ rankings: formattedRankings });
   } catch (err) {
-    console.error("Error fetching rankings:", err);
+    console.error(" 오류가 발생했습니다 ! :", err);
     next(err);
   }
 };

--- a/src/logics/ranking.logic.js
+++ b/src/logics/ranking.logic.js
@@ -1,6 +1,6 @@
 import { prisma } from '../utils/prisma/index.js';
 
-export const getRankings = async (req, res) => {
+export const getRankings = async (req, res, next) => {
   try {
     const rankings = await prisma.record.findMany({
       orderBy: { score: 'desc' },
@@ -8,9 +8,9 @@ export const getRankings = async (req, res) => {
     });
 
     const formattedRankings = rankings.map((record, index) => ({
-      rank: index + 1, 
-       // 점수가 높은 순서대로 정렬된 결과에서 순위 매기기 , index 는 0부터 시작 1을 더해 순위로 변환 -> 이렇게 하면 점수가 높은 순으로 순위표 작성
+      rank: index + 1,
       user_id: record.userId,
+      user_name: record.user.userName, 
       score: record.score,
       wins: record.win,
       draws: record.draw,
@@ -19,6 +19,7 @@ export const getRankings = async (req, res) => {
 
     res.json({ rankings: formattedRankings });
   } catch (err) {
-    next(err); // 오류 발생 시 중앙 오류 처리 미들웨어로 전달
+    console.error("Error fetching rankings:", err);
+    next(err);
   }
 };

--- a/src/logics/score.logic.js
+++ b/src/logics/score.logic.js
@@ -8,66 +8,130 @@ const weight = {
   stamina: 0.2,
 };
 
-const updateRecords = async (userId, opponentId, userScoreChange, opponentScoreChange, userResult, opponentResult, teamIdA, teamIdB) => {
-  const userRecord = await prisma.record.findUnique({ where: { userId } });
-  const opponentRecord = await prisma.record.findUnique({ where: { userId: opponentId } });
+// 유저 승리 시 점수 업데이트 및 기록 저장 함수
+export const handleWin = async (userId, opponentId, teamIdA, teamIdB) => {
+  try {
+    const userRecord = await prisma.record.findUnique({ where: { userId } });
+    const opponentRecord = await prisma.record.findUnique({ where: { userId: opponentId } });
 
-  await prisma.$transaction([
-    prisma.record.update({
+    const updatedUserScore = userRecord.score + 10;
+    const updatedOpponentScore = opponentRecord.score - 10;
+
+    await prisma.record.update({
       where: { userId },
       data: {
-        score: userRecord.score + userScoreChange,
-        win: userResult === 'win' ? userRecord.win + 1 : userRecord.win,
-        lose: userResult === 'lose' ? userRecord.lose + 1 : userRecord.lose,
-        draw: userResult === 'draw' ? userRecord.draw + 1 : userRecord.draw,
+        score: updatedUserScore,
+        win: userRecord.win + 1,
       },
-    }),
-    prisma.record.update({
+    });
+
+    await prisma.record.update({
       where: { userId: opponentId },
       data: {
-        score: opponentRecord.score + opponentScoreChange,
-        win: opponentResult === 'win' ? opponentRecord.win + 1 : opponentRecord.win,
-        lose: opponentResult === 'lose' ? opponentRecord.lose + 1 : opponentRecord.lose,
-        draw: opponentResult === 'draw' ? opponentRecord.draw + 1 : opponentRecord.draw,
+        score: updatedOpponentScore,
+        lose: opponentRecord.lose + 1,
       },
-    }),
-    prisma.matchHistory.create({
+    });
+
+    await prisma.matchHistory.create({
       data: {
         userIdA: userId,
         userIdB: opponentId,
         teamIdA,
         teamIdB,
-        resultA: userResult,
-        resultB: opponentResult,
-        scoreChangeA: userScoreChange,
-        scoreChangeB: opponentScoreChange,
+        resultA: 'win',
+        resultB: 'lose',
+        scoreChangeA: 10,
+        scoreChangeB: -10,
         matchTime: new Date(),
       },
-    })
-  ]);
-};
+    });
 
-export const handleWin = async (userId, opponentId, teamIdA, teamIdB) => {
-  try {
-    await updateRecords(userId, opponentId, 10, -10, 'win', 'lose', teamIdA, teamIdB);
-    return { message: '게임에서 승리하였습니다.', new_score: userRecord.score + 10 };
+    return { message: '게임에서 승리하였습니다.', new_score: updatedUserScore };
   } catch (err) {
     throw new Error(err.message);
   }
 };
 
+// 유저 패배 시 점수 업데이트 및 기록 저장 함수
 export const handleLose = async (userId, opponentId, teamIdA, teamIdB) => {
   try {
-    await updateRecords(userId, opponentId, -10, 10, 'lose', 'win', teamIdA, teamIdB);
-    return { message: '게임에서 패배하였습니다.', new_score: userRecord.score - 10 };
+    const userRecord = await prisma.record.findUnique({ where: { userId } });
+    const opponentRecord = await prisma.record.findUnique({ where: { userId: opponentId } });
+
+    const updatedUserScore = userRecord.score - 10;
+    const updatedOpponentScore = opponentRecord.score + 10;
+
+    await prisma.record.update({
+      where: { userId },
+      data: {
+        score: updatedUserScore,
+        lose: userRecord.lose + 1,
+      },
+    });
+
+    await prisma.record.update({
+      where: { userId: opponentId },
+      data: {
+        score: updatedOpponentScore,
+        win: opponentRecord.win + 1,
+      },
+    });
+
+    await prisma.matchHistory.create({
+      data: {
+        userIdA: userId,
+        userIdB: opponentId,
+        teamIdA,
+        teamIdB,
+        resultA: 'lose',
+        resultB: 'win',
+        scoreChangeA: -10,
+        scoreChangeB: 10,
+        matchTime: new Date(),
+      },
+    });
+
+    return { message: '게임에서 패배하였습니다.', new_score: updatedUserScore };
   } catch (err) {
     throw new Error(err.message);
   }
 };
 
+// 유저 무승부 시 점수 업데이트 및 기록 저장 함수
 export const handleDraw = async (userId, opponentId, teamIdA, teamIdB) => {
   try {
-    await updateRecords(userId, opponentId, 0, 0, 'draw', 'draw', teamIdA, teamIdB);
+    const userRecord = await prisma.record.findUnique({ where: { userId } });
+    const opponentRecord = await prisma.record.findUnique({ where: { userId: opponentId } });
+
+    await prisma.record.update({
+      where: { userId },
+      data: {
+        draw: userRecord.draw + 1,
+      },
+    });
+
+    await prisma.record.update({
+      where: { userId: opponentId },
+      data: {
+        draw: opponentRecord.draw + 1,
+      },
+    });
+
+    await prisma.matchHistory.create({
+      data: {
+        userIdA: userId,
+        userIdB: opponentId,
+        teamIdA,
+        teamIdB,
+        resultA: 'draw',
+        resultB: 'draw',
+        scoreChangeA: 0,
+        scoreChangeB: 0,
+        matchTime: new Date(),
+      },
+    });
+
     return { message: '무승부', new_score: userRecord.score };
   } catch (err) {
     throw new Error(err.message);

--- a/src/routes/match-history.router.js
+++ b/src/routes/match-history.router.js
@@ -4,12 +4,6 @@ import authMiddleware from '../middlewares/auth.middleware.js';
 
 const router = express.Router();
 
-router.get('/history/:userId', authMiddleware, (req, res, next) => {
-  try {
-    getMatchHistory(req, res, next);
-  } catch (error) {
-    next(error);
-  }
-});
+router.get('/history/:teamId', authMiddleware, getMatchHistory);
 
 export default router;

--- a/src/routes/ranking.router.js
+++ b/src/routes/ranking.router.js
@@ -4,13 +4,6 @@ import authMiddleware from '../middlewares/auth.middleware.js';
 
 const router = express.Router();
 
-router.get('/rankings', authMiddleware, (req, res, next) => {
-  try {
-    getRankings(req, res, next);
-  } catch (error) { // 오류 발생 시 중앙 오류 처리 미들웨어로 전달
-    next(error);
-  }
-});
+router.get('/rankings', authMiddleware, getRankings);
 
 export default router;
-

--- a/src/utils/prisma/index.js
+++ b/src/utils/prisma/index.js
@@ -2,8 +2,9 @@ import { PrismaClient } from '@prisma/client';
 
 export const prisma = new PrismaClient({
   log: ['query', 'info', 'warn', 'error'],
-
   errorFormat: 'pretty',
 });
 
-
+prisma.$on('error', (e) => {
+  console.error('Prisma Client Error:', e); // prisma 클라이언트 초기화 시 에러 핸들링 
+});


### PR DESCRIPTION
ranking.logic.js  - 좀 더 포맷팅된 데이터로 반환 (userName) , 에러 핸들링 메세지 추가
ranking.router.js - 가독성 up , logic에 비즈니스 로직 넘겨줌 , 에러핸들링 중복 삭제
match-history.router.js - 에러 핸들링 중복 삭제, try-catch 블록을 라우터에서 한번만 사용
app.js - 가독성 높이기 위해서 라우터 모듈 배열로 정리, 환경 변수를 젤 위에 배치하여 로드하도록 함
utils/prisma/index.js - prisma 클라이언트 초기화 시 에러 핸들링 추가
match-history.logic.js -teamIdA와 teamIdB를 사용해서 teamId 추출, record 테이블에서 실시간 점수 조회, include 사용
